### PR TITLE
Add test to compare the inference result of TF and BigDL

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
@@ -98,6 +98,6 @@ object Squeeze {
   def apply[T: ClassTag](
     dims : Array[Int], batchMode: Boolean)(implicit ev: TensorNumeric[T])
   : Squeeze[T] = {
-    new Squeeze[T](dims, batchMode)
+    new Squeeze[T](dims.sortWith(_>_), batchMode)
   }
 }

--- a/spark/dl/src/test/resources/tf/alexnet.py
+++ b/spark/dl/src/test/resources/tf/alexnet.py
@@ -26,17 +26,21 @@ def main():
     1. mkdir model
     2. python alexnet.py
     3. wget https://raw.githubusercontent.com/tensorflow/tensorflow/v1.0.0/tensorflow/python/tools/freeze_graph.py
-    4. python freeze_graph.py --input_graph model/alexnet.pbtxt --input_checkpoint model/alexnet.chkp --output_node_names="alexnet_v2/fc8/squeezed" --output_graph alexnet.pb
+    4. python freeze_graph.py --input_graph model/alexnet.pbtxt --input_checkpoint model/alexnet.chkp --output_node_names="alexnet_v2/fc8/squeezed,output" --output_graph alexnet_save.pb
     """
     dir = os.path.dirname(os.path.realpath(__file__))
     batch_size = 5
     height, width = 224, 224
-    inputs = tf.placeholder(tf.float32, [None, height, width, 3])
-    net, end_points  = alexnet.alexnet_v2(inputs)
+    #inputs = tf.placeholder(tf.float32, [None, height, width, 3])
+    inputs = tf.Variable(tf.random_uniform((1, height, width, 3)), name='input')
+    net, end_points  = alexnet.alexnet_v2(inputs, is_training=False)
+    output = tf.Variable(tf.random_uniform(tf.shape(net)),name='output')
+    result = tf.assign(output,net)
     saver = tf.train.Saver()
     with tf.Session() as sess:
         init = tf.global_variables_initializer()
-        sess.run(init)
+        sess.run(init)   
+        print(sess.run(result))
         checkpointpath = saver.save(sess, dir + '/model/alexnet.chkp')
         tf.train.write_graph(sess.graph, dir + '/model', 'alexnet.pbtxt')
         tf.summary.FileWriter(dir + '/log', sess.graph)

--- a/spark/dl/src/test/resources/tf/vgg16.py
+++ b/spark/dl/src/test/resources/tf/vgg16.py
@@ -26,17 +26,21 @@ def main():
     1. mkdir model
     2. python vgg16.py
     3. wget https://raw.githubusercontent.com/tensorflow/tensorflow/v1.0.0/tensorflow/python/tools/freeze_graph.py
-    4. python freeze_graph.py --input_graph model/vgg16.pbtxt --input_checkpoint model/vgg16.chkp --output_node_names="vgg_16/fc8/squeezed" --output_graph vgg16.pb
+    4. python freeze_graph.py --input_graph model/vgg16.pbtxt --input_checkpoint model/vgg16.chkp --output_node_names="vgg_16/fc8/squeezed,output" --output_graph vgg16_save.pb
     """
     dir = os.path.dirname(os.path.realpath(__file__))
     batch_size = 5
     height, width = 224, 224
-    inputs = tf.placeholder(tf.float32, [None, height, width, 3])
-    net, end_points  = vgg.vgg_16(inputs)
+    #inputs = tf.placeholder(tf.float32, [None, height, width, 3])
+    inputs = tf.Variable(tf.random_uniform((1, height, width, 3)), name='input')
+    net, end_points  = vgg.vgg_16(inputs, is_training = False)
+    output = tf.Variable(tf.random_uniform(tf.shape(net)),name='output')
+    result = tf.assign(output,net)
     saver = tf.train.Saver()
     with tf.Session() as sess:
         init = tf.global_variables_initializer()
         sess.run(init)
+        sess.run(result)
         checkpointpath = saver.save(sess, dir + '/model/vgg16.chkp')
         tf.train.write_graph(sess.graph, dir + '/model', 'vgg16.pbtxt')
         tf.summary.FileWriter(dir + '/log', sess.graph)

--- a/spark/dl/src/test/resources/tf/vgg19.py
+++ b/spark/dl/src/test/resources/tf/vgg19.py
@@ -26,17 +26,21 @@ def main():
     1. mkdir model
     2. python vgg19.py
     3. wget https://raw.githubusercontent.com/tensorflow/tensorflow/v1.0.0/tensorflow/python/tools/freeze_graph.py
-    4. python freeze_graph.py --input_graph model/vgg19.pbtxt --input_checkpoint model/vgg19.chkp --output_node_names="vgg_19/fc8/squeezed" --output_graph vgg19.pb
+    4. python freeze_graph.py --input_graph model/vgg19.pbtxt --input_checkpoint model/vgg19.chkp --output_node_names="vgg_19/fc8/squeezed,output" --output_graph vgg19_save.pb
     """
     dir = os.path.dirname(os.path.realpath(__file__))
     batch_size = 5
     height, width = 224, 224
-    inputs = tf.placeholder(tf.float32, [None, height, width, 3])
-    net, end_points  = vgg.vgg_19(inputs)
+    #inputs = tf.placeholder(tf.float32, [None, height, width, 3])
+    inputs = tf.Variable(tf.random_uniform((1, height, width, 3)), name='input')
+    net, end_points  = vgg.vgg_19(inputs, is_training = False)
+    output = tf.Variable(tf.random_uniform(tf.shape(net)),name='output')
+    result = tf.assign(output,net)
     saver = tf.train.Saver()
     with tf.Session() as sess:
         init = tf.global_variables_initializer()
         sess.run(init)
+        sess.run(result)
         checkpointpath = saver.save(sess, dir + '/model/vgg19.chkp')
         tf.train.write_graph(sess.graph, dir + '/model', 'vgg19.pbtxt')
         tf.summary.FileWriter(dir + '/log', sess.graph)

--- a/spark/dl/src/test/resources/tf/vgga.py
+++ b/spark/dl/src/test/resources/tf/vgga.py
@@ -26,17 +26,21 @@ def main():
     1. mkdir model
     2. python vgga.py
     3. wget https://raw.githubusercontent.com/tensorflow/tensorflow/v1.0.0/tensorflow/python/tools/freeze_graph.py
-    4. python freeze_graph.py --input_graph model/vgga.pbtxt --input_checkpoint model/vgga.chkp --output_node_names="vgg_a/fc8/squeezed" --output_graph vgga.pb
+    4. python freeze_graph.py --input_graph model/vgga.pbtxt --input_checkpoint model/vgga.chkp --output_node_names="vgg_a/fc8/squeezed,output" --output_graph vgga_save.pb
     """
     dir = os.path.dirname(os.path.realpath(__file__))
     batch_size = 5
     height, width = 224, 224
-    inputs = tf.placeholder(tf.float32, [None, height, width, 3])
-    net, end_points  = vgg.vgg_a(inputs)
+    #inputs = tf.placeholder(tf.float32, [None, height, width, 3])
+    inputs = tf.Variable(tf.random_uniform((1, height, width, 3)), name='input')
+    net, end_points  = vgg.vgg_a(inputs, is_training = False)
+    output = tf.Variable(tf.random_uniform(tf.shape(net)),name='output')
+    result = tf.assign(output,net)
     saver = tf.train.Saver()
     with tf.Session() as sess:
         init = tf.global_variables_initializer()
         sess.run(init)
+        sess.run(result)
         checkpointpath = saver.save(sess, dir + '/model/vgga.chkp')
         tf.train.write_graph(sess.graph, dir + '/model', 'vgga.pbtxt')
         tf.summary.FileWriter(dir + '/log', sess.graph)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqueezeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqueezeSpec.scala
@@ -82,7 +82,7 @@ class SqueezeSpec extends FlatSpec with BeforeAndAfter with Matchers {
     println("Test case : Squeeze, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
   }
 
-  "A Squeeze(2, 2)" should "generate correct output and grad" in {
+  "A Squeeze(2, 3)" should "generate correct output and grad" in {
     val layer = Squeeze[Double](2, 3)
     val input = Tensor[Double](1, 1, 2, 2).apply1(_ => Random.nextDouble())
     val gradOutput = Tensor[Double](2, 2).apply1(_ => Random.nextDouble())
@@ -106,5 +106,17 @@ class SqueezeSpec extends FlatSpec with BeforeAndAfter with Matchers {
     gradInput should be (luaGradInput)
 
     println("Test case : Squeeze, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
+  }
+
+  "A Squeeze(Array(2, 3), true)" should "generate correct output and grad" in {
+    val layer = Squeeze[Double](Array(2, 3), true)
+    val input = Tensor[Double](2, 2, 1, 1).apply1(_ => Random.nextDouble())
+    val gradOutput = Tensor[Double](2, 2).apply1(_ => Random.nextDouble())
+
+    val output = layer.forward(input)
+    val gradInput = layer.backward(input, gradOutput)
+
+    output.size() should be (Array(2, 2))
+    gradInput.size() should be (Array(2, 2, 1, 1))
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TensorflowLoaderSpec.scala
@@ -25,6 +25,7 @@ import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import scala.math._
 
 object TensorflowLoaderSpec {
   private val data1 = Array(0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.1f)
@@ -345,6 +346,117 @@ class TensorflowLoaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val gradient2 = Tensor[Float](5, 1001).rand()
     model.forward(input)
     model.backward(input, T(gradient1, gradient2))
+  }
+
+  "TensorFlow loader" should "have the same inferrence result with tensorflow " +
+    "after loading slim alexnet" in {
+    val resource = getClass().getClassLoader().getResource("tf")
+    val path = processPath(resource.getPath()) + JFile.separator + "alexnet_save.pb"
+    val results = TensorflowLoader.parse(path)
+    val tfGraph = TensorflowLoader.buildTFGraph(results.subList(0, results.size()-1))
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      Seq("alexnet_v2/fc8/squeezed"))
+    val input = TFToBigDL.toTensor(results.get(0).getAttrMap.get("value").getTensor)
+      .transpose(2, 4).transpose(3, 4).contiguous()
+    val gradient = Tensor[Float](1, 1000).rand()
+    val tfResult = TFToBigDL.toTensor(results.get(results.size()-1)
+      .getAttrMap.get("value").getTensor)
+    val BigDLResult = model.forward(input)
+
+    tfResult.map( BigDLResult.toTensor, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-7);
+      v2
+    })
+    model.backward(input, gradient)
+  }
+
+
+  "TensorFlow loader" should "have the same inferrence result with tensorflow " +
+    "after loading slim vgga" in {
+    val resource = getClass().getClassLoader().getResource("tf")
+    val path = processPath(resource.getPath()) + JFile.separator + "vgga_save.pb"
+    val results = TensorflowLoader.parse(path)
+    val tfGraph = TensorflowLoader.buildTFGraph(results.subList(0, results.size()-1))
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      Seq("vgg_a/fc8/squeezed"))
+    val input = TFToBigDL.toTensor(results.get(0).getAttrMap.get("value").getTensor)
+      .transpose(2, 4).transpose(3, 4).contiguous()
+    val gradient = Tensor[Float](1, 1000).rand()
+    val tfResult = TFToBigDL.toTensor(results.get(results.size()-1)
+      .getAttrMap.get("value").getTensor)
+    val BigDLResult = model.forward(input)
+
+    tfResult.map( BigDLResult.toTensor, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-7);
+      v2
+    })
+    model.backward(input, gradient)
+  }
+
+  "TensorFlow loader" should "have the same inferrence result with tensorflow " +
+    "after loading slim vgg_16" in {
+    val resource = getClass().getClassLoader().getResource("tf")
+    val path = processPath(resource.getPath()) + JFile.separator + "vgg16_save.pb"
+    val results = TensorflowLoader.parse(path)
+    val tfGraph = TensorflowLoader.buildTFGraph(results.subList(0, results.size()-1))
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      Seq("vgg_16/fc8/squeezed"))
+    val input = TFToBigDL.toTensor(results.get(0).getAttrMap.get("value").getTensor)
+      .transpose(2, 4).transpose(3, 4).contiguous()
+    val gradient = Tensor[Float](1, 1000).rand()
+    val tfResult = TFToBigDL.toTensor(results.get(results.size()-1)
+      .getAttrMap.get("value").getTensor)
+    val BigDLResult = model.forward(input)
+
+    tfResult.map( BigDLResult.toTensor, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-7);
+      v2
+    })
+    model.backward(input, gradient)
+  }
+
+  "TensorFlow loader" should "have the same inferrence result with tensorflow " +
+    "after loading slim vgg_19" in {
+    val resource = getClass().getClassLoader().getResource("tf")
+    val path = processPath(resource.getPath()) + JFile.separator + "vgg19_save.pb"
+    val results = TensorflowLoader.parse(path)
+    val tfGraph = TensorflowLoader.buildTFGraph(results.subList(0, results.size()-1))
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      Seq("vgg_19/fc8/squeezed"))
+    val input = TFToBigDL.toTensor(results.get(0).getAttrMap.get("value").getTensor)
+      .transpose(2, 4).transpose(3, 4).contiguous()
+    val gradient = Tensor[Float](1, 1000).rand()
+    val tfResult = TFToBigDL.toTensor(results.get(results.size()-1)
+      .getAttrMap.get("value").getTensor)
+    val BigDLResult = model.forward(input)
+
+    tfResult.map( BigDLResult.toTensor, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-7);
+      v2
+    })
+    model.backward(input, gradient)
+  }
+
+  "TensorFlow loader" should "have the same inferrence result with tensorflow " +
+    "after loading slim overfeat" in {
+    val resource = getClass().getClassLoader().getResource("tf")
+    val path = processPath(resource.getPath()) + JFile.separator + "overfeat_save.pb"
+    val results = TensorflowLoader.parse(path)
+    val tfGraph = TensorflowLoader.buildTFGraph(results.subList(0, results.size()-1))
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      Seq("overfeat/fc8/squeezed"))
+    val input = TFToBigDL.toTensor(results.get(0).getAttrMap.get("value").getTensor)
+      .transpose(2, 4).transpose(3, 4).contiguous()
+    val gradient = Tensor[Float](1, 1000).rand()
+    val tfResult = TFToBigDL.toTensor(results.get(results.size()-1)
+      .getAttrMap.get("value").getTensor)
+    val BigDLResult = model.forward(input)
+
+    tfResult.map( BigDLResult.toTensor, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-7);
+      v2
+    })
+    model.backward(input, gradient)
   }
 
   private def processPath(path: String): String = {


### PR DESCRIPTION
cherry pick squeeze

Add test to compare the inference result of TF and BigDL

## What changes were proposed in this pull request?
Use random variable as the input of the TF model and use variable to save the model output in the Tensorflow. Reload the input in BigDL and compare the outputs.


## How was this patch tested?

Unit test

