### PR TITLE
Add backward test in LeNet and AlexNet

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
@@ -122,7 +122,8 @@ object TensorflowLoader{
       tfGraph: DirectedGraph[NodeDef],
       inputs: Seq[String],
       outputs: Seq[String],
-      byteOrder: ByteOrder
+      byteOrder: ByteOrder,
+      ctx: Option[Context[T]] = None
     )(implicit ev: TensorNumeric[T]): Module[T] = {
     import scala.collection.JavaConverters._
 
@@ -131,7 +132,7 @@ object TensorflowLoader{
       Node[AbstractModule[Activity, Tensor[T], T]]]()
     val nameToNode =
       new mutable.HashMap[String, Node[AbstractModule[Activity, Tensor[T], T]]]()
-    val context = new mutable.HashMap[NodeDef, (Tensor[T], Tensor[T])]
+    val context = ctx.getOrElse(new mutable.HashMap[NodeDef, (Tensor[T], Tensor[T])])
 
     // BFS to keep the input order same
     tfGraph.BFS.foreach(n => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
@@ -100,7 +100,12 @@ object TensorflowLoader{
 
     // Connect nodes
     name2Node.valuesIterator.foreach(n => {
-      n.element.getInputList.asScala.foreach(name2Node(_) -> n)
+      n.element.getInputList.asScala.foreach{
+        input =>
+          // It is tricky here, remove the first char in the name of control dep node
+          val name = if (input.charAt(0) == '^') input.substring(1) else input
+          name2Node(name) -> n
+      }
     })
 
     // Build graph

--- a/spark/dl/src/test/resources/tf/models/alexnet.py
+++ b/spark/dl/src/test/resources/tf/models/alexnet.py
@@ -33,7 +33,7 @@ def main():
     for n in end_points:
         print(n + " => " + str(end_points[n]))
     net_outputs = map(lambda x: tf.get_default_graph().get_tensor_by_name(x), argv[2].split())
-    run_model(net_outputs, argv[1])
+    run_model(net_outputs, argv[1], 'alexnet')
 
 if __name__ == "__main__":
     main()

--- a/spark/dl/src/test/resources/tf/models/lenet.py
+++ b/spark/dl/src/test/resources/tf/models/lenet.py
@@ -33,7 +33,7 @@ def main():
     for n in end_points:
         print(n + " => " + str(end_points[n]))
     net_outputs = map(lambda x: tf.get_default_graph().get_tensor_by_name(x), argv[2].split())
-    run_model(net_outputs, argv[1])
+    run_model(net_outputs, argv[1], 'LeNet')
 
 if __name__ == "__main__":
     main()

--- a/spark/dl/src/test/resources/tf/models/util.py
+++ b/spark/dl/src/test/resources/tf/models/util.py
@@ -57,14 +57,36 @@ def merge_checkpoint(input_graph,
     with gfile.GFile(output_graph, "wb") as f:
         f.write(output_graph_def.SerializeToString())
 
-def run_model(end_points, output_path):
+def run_model(end_points, output_path, model_scope=None):
     outputs = []
     results = []
+    grad_inputs = []
+    grad_vars = []
+    grad_results = []
+    trainable_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, scope=model_scope)
     i = 0
+    opt = tf.train.GradientDescentOptimizer(0.01)
     for end_point in end_points:
         output = tf.Variable(tf.random_uniform(tf.shape(end_point)), name='output' + str(i))
         outputs.append(output)
         results.append(tf.assign(output, end_point, name = 'assign' + str(i)))
+
+        # set up backward variables
+        # filter None tensor
+        tmp_vars = filter(lambda x: tf.gradients(end_point, x) != [None], trainable_vars)
+        # set up random gradient input
+        grad_input = tf.Variable(tf.random_uniform(tf.shape(end_point)), name='grad_input' + str(i))
+        grad_inputs.append(grad_input)
+        # compute gradients with random input
+        backward = opt.compute_gradients(end_point, var_list=tmp_vars, grad_loss=grad_input)
+        j = 0
+        for gradients, tensor in backward:
+            grad_var = tf.Variable(tf.random_uniform(tf.shape(tensor)), 
+                name='{}_grad{}'.format(tensor.name[:-2], i))
+            grad_vars.append(grad_var)
+            grad_result = tf.assign(grad_var, gradients, name='grad_assign' + str((i+1)*j))
+            grad_results.append(grad_result)
+            j = j + 1
         i = i + 1
 
     saver = tf.train.Saver()
@@ -72,12 +94,19 @@ def run_model(end_points, output_path):
         init = tf.global_variables_initializer()
         sess.run(init) 
         sess.run(results)
+        sess.run(grad_results)
         saver.save(sess, output_path + '/model.chkp')
         tf.train.write_graph(sess.graph, output_path, 'model.pbtxt')
+        tf.summary.FileWriter(output_path + '/log', sess.graph)
 
     input_graph = output_path + "/model.pbtxt"    
     input_checkpoint = output_path + "/model.chkp"
     output_file = output_path + "/model.pb"
 
-    merge_checkpoint(input_graph, input_checkpoint, map(lambda x: 'assign' + str(x), range(len(end_points))), output_file)
+    output_nodes = map(lambda x: 'assign' + str(x), range(len(end_points)))
+    grades_nodes = map(lambda x: 'grad_assign' + str(x), range(len(grad_results)))
+    output_nodes.extend(grades_nodes)
+
+    # merge_checkpoint(input_graph, input_checkpoint, map(lambda x: 'assign' + str(x), range(len(end_points))), output_file)
+    merge_checkpoint(input_graph, input_checkpoint, output_nodes, output_file)
 

--- a/spark/dl/src/test/resources/tf/models/util.py
+++ b/spark/dl/src/test/resources/tf/models/util.py
@@ -97,7 +97,7 @@ def run_model(end_points, output_path, model_scope=None):
         sess.run(grad_results)
         saver.save(sess, output_path + '/model.chkp')
         tf.train.write_graph(sess.graph, output_path, 'model.pbtxt')
-        tf.summary.FileWriter(output_path + '/log', sess.graph)
+        # tf.summary.FileWriter(output_path + '/log', sess.graph)
 
     input_graph = output_path + "/model.pbtxt"    
     input_checkpoint = output_path + "/model.chkp"

--- a/spark/dl/src/test/resources/tf/models/util.py
+++ b/spark/dl/src/test/resources/tf/models/util.py
@@ -81,6 +81,9 @@ def run_model(end_points, output_path, model_scope=None):
         backward = opt.compute_gradients(end_point, var_list=tmp_vars, grad_loss=grad_input)
         j = 0
         for gradients, tensor in backward:
+            print gradients
+            print tensor
+            print '\n'
             grad_var = tf.Variable(tf.random_uniform(tf.shape(tensor)), 
                 name='{}_grad{}'.format(tensor.name[:-2], i))
             grad_vars.append(grad_var)

--- a/spark/dl/src/test/resources/tf/models/util.py
+++ b/spark/dl/src/test/resources/tf/models/util.py
@@ -81,9 +81,6 @@ def run_model(end_points, output_path, model_scope=None):
         backward = opt.compute_gradients(end_point, var_list=tmp_vars, grad_loss=grad_input)
         j = 0
         for gradients, tensor in backward:
-            print gradients
-            print tensor
-            print '\n'
             grad_var = tf.Variable(tf.random_uniform(tf.shape(tensor)), 
                 name='{}_grad{}'.format(tensor.name[:-2], i))
             grad_vars.append(grad_var)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -371,9 +371,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     val tfNodes = TensorflowLoader.parse(modelFile)
 
     // filter node for gradient computing
-    val graphNode = tfNodes.asScala.filter(!_.getName.contains("grad"))
-    // tfNodes.asScala.foreach(println(_))
-    val tfGraph = TensorflowLoader.buildTFGraph(graphNode.asJava, endPoints.map(_.split(":")(0)))
+    val tfGraph = TensorflowLoader.buildTFGraph(tfNodes, endPoints.map(_.split(":")(0)))
     val context = new mutable.HashMap[NodeDef, (Tensor[Float], Tensor[Float])]
     val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
       endPoints.map(_.split(":")(0)), ByteOrder.LITTLE_ENDIAN, Some(context))
@@ -437,7 +435,6 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
       val pairs = context.keySet.map{
         x =>
           val name = s"${x.getName}_grad$i"
-          // tfGradTensorsMap.keySet should contain(name)
           (context(x)._2, tfGradTensorsMap.get(name).getOrElse(null))
       }.toSeq.filter(_._2 != null)
       comparePair ++ pairs

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -33,6 +33,7 @@ import org.tensorflow.framework.NodeDef
 import scala.collection.mutable
 import scala.sys.process._
 import scala.math._
+import scala.reflect.ClassTag
 
 object TensorflowLoaderSpec {
   private val data1 = Array(0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.1f)
@@ -284,63 +285,86 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
   }
 
   "Tensorflow lenet" should "be load correctly" in {
-    testModel("lenet", Seq("LeNet/pool2/MaxPool:0"), true).foreach {
+    testModelForward("lenet", Seq("LeNet/pool2/MaxPool:0"), true).foreach {
       case(tf, bigdl) =>
-        tf.almostEqual(bigdl, 1e-6) should be(true)
+        val transpose = bigdl.transpose(2, 3).transpose(3, 4)
+        tf.almostEqual(transpose, 1e-6) should be(true)
+    }
+    testModelBackward("lenet", Seq("LeNet/pool2/MaxPool:0"), true,
+      Seq((4, 3), (3, 2))).foreach {
+      case(tf, bigdl) =>
+        if (tf.dim() == 4) {
+          val trans = tf.transpose(1, 4).transpose(2, 3).transpose(3, 4).contiguous()
+          trans.almostEqual(bigdl, 1e-4) should be(true)
+        }
+        else {
+          tf.almostEqual(bigdl, 1e-4) should be(true)
+        }
     }
   }
 
   "Tensorflow Alexnet" should "be load correctly" in {
-    testModel("alexnet", Seq("alexnet_v2/fc8/squeezed:0"), true).foreach {
+    testModelForward("alexnet", Seq("alexnet_v2/fc8/squeezed:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
+    }
+    testModelBackward("alexnet", Seq("alexnet_v2/fc8/squeezed:0"), true,
+      Seq.empty).foreach {
+      case(tf, bigdl) =>
+        if (tf.dim() == 4) {
+          val trans = tf.transpose(1, 4).transpose(2, 3).transpose(3, 4).contiguous()
+          trans.almostEqual(bigdl, 1e-4) should be(true)
+        }
+        else {
+          tf.almostEqual(bigdl, 1e-4) should be(true)
+        }
     }
   }
 
   "TensorFlow vgg_a" should "be load correctly" in {
-    testModel("vgga", Seq("vgg_a/fc8/squeezed:0"), true).foreach {
+    testModelForward("vgga", Seq("vgg_a/fc8/squeezed:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
     }
   }
 
   "TensorFlow vgg_16" should "be load correctly" in {
-    testModel("vgg16", Seq("vgg_16/fc8/squeezed:0"), true).foreach {
+    testModelForward("vgg16", Seq("vgg_16/fc8/squeezed:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
     }
   }
 
   "TensorFlow vgg_19" should "be load correctly" in {
-    testModel("vgg19", Seq("vgg_19/fc8/squeezed:0"), true).foreach {
+    testModelForward("vgg19", Seq("vgg_19/fc8/squeezed:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
     }
   }
 
   "TensorFlow overfeat" should "be load correctly" in {
-    testModel("overfeat", Seq("overfeat/fc8/squeezed:0"), true).foreach {
+    testModelForward("overfeat", Seq("overfeat/fc8/squeezed:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
     }
   }
 
   "TensorFlow inception_v3" should "be load correctly" in {
-    testModel("inception_v3", Seq("InceptionV3/Logits/SpatialSqueeze:0"), true).foreach {
+    testModelForward("inception_v3", Seq("InceptionV3/Logits/SpatialSqueeze:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
     }
   }
 
   "TensorFlow resnet_v1" should "be load correctly" in {
-    testModel("resnet_v1", Seq("resnet_v1_101/SpatialSqueeze:0"), true).foreach {
+    testModelForward("resnet_v1", Seq("resnet_v1_101/SpatialSqueeze:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-6) should be(true)
     }
   }
 
   "TensorFlow inception_resnet_v2" should "be load correctly" in {
-    testModel("inception_resnet_v2", Seq("InceptionResnetV2/Logits/Logits/BiasAdd:0",
+    testModelForward("inception_resnet_v2", Seq("InceptionResnetV2/Logits/Logits/BiasAdd:0",
       "InceptionResnetV2/AuxLogits/Logits/BiasAdd:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-7) should be(true)
@@ -348,7 +372,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
   }
 
 
-  private def testModel(modelName: String, endPoints: Seq[String], transInput: Boolean)
+  private def testModelForward(modelName: String, endPoints: Seq[String], transInput: Boolean)
   : Seq[(Tensor[Float], Tensor[Float])] = {
 
     tfCheck()
@@ -398,17 +422,81 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
       (1 to endPoints.length).map(t[Tensor[Float]](_))
     }
 
-    // do backward
+    val comparePair = tfOutputTensors.zip(bigdlOutputs).map{
+      x =>
+        val tensor = TensorflowToBigDL.toTensor(x._1, ByteOrder.LITTLE_ENDIAN)
+        (tensor, x._2)
+    }
+    tmpLocation.deleteOnExit()
+    comparePair
+  }
+
+  private def testModelBackward(
+    modelName: String,
+    endPoints: Seq[String],
+    transInput: Boolean,
+    transOutputSeq: Seq[(Int, Int)]): Seq[(Tensor[Float], Tensor[Float])] = {
+
+    tfCheck()
+    // Generate command and prepare the temp folder
+    val s = JFile.separator
+    val modelsFolder = processPath(getClass().getClassLoader().getResource("tf").getPath()) +
+      s + "models"
+    val modelScript = modelsFolder + s + s"$modelName.py"
+    val tmpLocation = java.io.File.createTempFile("tensorflowLoaderTest" + UUID.randomUUID(),
+      modelName)
+    tmpLocation.delete()
+    tmpLocation.mkdir()
+
+    require(runPython(s"$modelScript $tmpLocation ${endPoints.mkString(",")}"),
+      "error when run the model script")
+
+    // Load the model and input/output tensors
+    import collection.JavaConverters._
+    val modelFile = tmpLocation + s + "model.pb"
+    val tfNodes = TensorflowLoader.parse(modelFile)
+
+    // filter node for gradient computing
+    val tfGraph = TensorflowLoader.buildTFGraph(tfNodes, endPoints.map(_.split(":")(0)))
+    val context = new mutable.HashMap[NodeDef, (Tensor[Float], Tensor[Float])]
+    val model = TensorflowLoader.buildBigDLModel(tfGraph, Seq("input"),
+      endPoints.map(_.split(":")(0)), ByteOrder.LITTLE_ENDIAN, Some(context))
+
+    // Compare the tensor contents
+    val tfInputTensor = tfNodes.asScala.filter(_.getName == "input")(0)
+      .getAttrMap.get("value").getTensor
+
+    val input = TensorflowToBigDL.toTensor(tfInputTensor,
+      ByteOrder.LITTLE_ENDIAN)
+
+    val transposeInput = if (transInput) {
+      input.transpose(2, 4).transpose(3, 4).contiguous()
+    } else {
+      input
+    }
+
+    val bigdlOutputs = if (endPoints.length == 1) {
+      Seq(model.forward(transposeInput).toTensor)
+    } else {
+      val t = model.forward(transposeInput).toTable
+      (1 to endPoints.length).map(t[Tensor[Float]](_))
+    }
+
+    // get gradient input of tensorflow
     val gradInputs = (0 until endPoints.length).map{
       i =>
         val t = tfNodes.asScala.filter(_.getName == s"grad_input$i")(0)
           .getAttrMap.get("value").getTensor
-        val tensor = TensorflowToBigDL.toTensor(t, ByteOrder.LITTLE_ENDIAN)
-        if (transInput && tensor.dim() == 4) {
-          tensor.transpose(4, 3).transpose(3, 2)
-        } else {
-          tensor
+        var tensor = TensorflowToBigDL.toTensor(t, ByteOrder.LITTLE_ENDIAN)
+        for (trans <- transOutputSeq) {
+          tensor = tensor.transpose(trans._1, trans._2)
         }
+        tensor.contiguous()
+    }
+
+    // check shape equality here
+    for (i <- 0 until endPoints.length) {
+      bigdlOutputs(i).size() should be(gradInputs(i).size())
     }
 
     // find all gradients tensor in tensorflow graph
@@ -419,29 +507,31 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
           TensorflowToBigDL.toTensor(t.getAttrMap.get("value").getTensor, ByteOrder.LITTLE_ENDIAN)
     }.toMap
 
-    val comparePair = tfOutputTensors.zip(bigdlOutputs).map{
-      x =>
-        val tensor = TensorflowToBigDL.toTensor(x._1, ByteOrder.LITTLE_ENDIAN)
-        if (transInput && tensor.dim() == 4) {
-          (tensor.transpose(4, 3).transpose(3, 2), x._2)
-        } else {
-          (tensor, x._2)
-        }
-    }
+
+    val comparePair = new mutable.ArrayBuffer[(Tensor[Float], Tensor[Float])]()
 
     // do backward for each output and its corresponding gradient input
     for (i <- 0 until gradInputs.length) {
+      // println(s"grad $i")
       model.backward(transposeInput, gradInputs(i))
       val pairs = context.keySet.map{
         x =>
           val name = s"${x.getName}_grad$i"
-          (context(x)._2, tfGradTensorsMap.get(name).getOrElse(null))
+          // if (tfGradTensorsMap.contains(name)) {
+          //   println(x.getName)
+          //   context(x)._2.size().foreach(println(_))
+          //   println(name)
+          //   tfGradTensorsMap(name).size().foreach(println(_))
+          // }
+          (tfGradTensorsMap.get(name).getOrElse(null), context(x)._2)
       }.toSeq.filter(_._2 != null)
-      comparePair ++ pairs
+      comparePair ++= pairs
     }
-
+    println(s"Compare ${comparePair.length} pairs of gradient vars in this graph")
+    tmpLocation.deleteOnExit()
     comparePair
   }
+
 
   private def processPath(path: String): String = {
     if (path.contains(":")) {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -287,11 +287,6 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     testModel("lenet", Seq("LeNet/pool2/MaxPool:0"), true).foreach {
       case(tf, bigdl) =>
         tf.almostEqual(bigdl, 1e-6) should be(true)
-      // case(tf, bigdl) =>
-      //   val transposed = bigdl.transpose(2, 3).transpose(3, 4)
-      //   transposed.size().foreach(println(_))
-      //   bigdl.size().foreach(println(_))
-      //   tf.almostEqual(transposed, 1e-6) should be(true)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add gradient points in models scripts to compute gradients in TensorFlow.
2. Change `TensorflowLoader` to accept context to store variables in BigDL for test
3. Separate `testModel` into `testModelForward` and `testModelBackward`

## How was this patch tested?

unit tests



